### PR TITLE
set_elevation! takes into account add_vertex_strategy

### DIFF
--- a/src/meshgraph.jl
+++ b/src/meshgraph.jl
@@ -528,7 +528,11 @@ get_elevation(g::AbstractMeshGraph, v::Integer)::Real =
 
 function set_elevation!(g::AbstractMeshGraph, v::Integer, elevation::Real)
     MG.set_prop!(g.graph, v, :elevation, elevation)
-    new_xyz = convert(g, uve(g, v))
+    if add_vertex_strategy(g) == USE_UVE
+        new_xyz = convert(g, uve(g, v))
+    else
+        new_xyz = [xyz(g, v)[1:2]..., elevation]
+    end
     MG.set_prop!(g.graph, v, :xyz, new_xyz)
 end
 


### PR DESCRIPTION
Hello, Paweł.

When implementing the code to generate a mesh with the grid aligned with UTM coordinates, I realized that the function `set_elevation!` should consider the `add_vertex_strategy` to correctly fill the `XYZ` coordinates.